### PR TITLE
Update intro page for JSR 370

### DIFF
--- a/chapters/intro.tex
+++ b/chapters/intro.tex
@@ -16,28 +16,28 @@ REST; for more information about the REST architectural style and RESTful Web se
 %This is a JCP public review draft; this specification is not yet final. A list of open issues can be found at:
 %This is a JCP final specification. A list of open issues can be found at:
 
-This is the final release of version 2.0. The issue tracking system for this release can be found at:
+This is the final release of version 2.1. The issue tracking system for this release can be found at:
 
 \begin{quote}
-http://java.net/jira/browse/JAX\_RS\_SPEC
+https://github.com/jax-rs/api/issues
 \end{quote}
 
 The corresponding Javadocs can be found online at:
 
 \begin{quote}
-http://jax-rs-spec.java.net/
+https://docs.oracle.com/javaee/7/api/javax/ws/rs/package-summary.html
 \end{quote}
 
 The reference implementation can be obtained from:
 
 \begin{quote}
-http://jersey.java.net/
+https://jersey.github.io
 \end{quote}
 
 The expert group seeks feedback from the community on any aspect of this specification, please send comments to:
 
 \begin{quote}
-users@jax-rs-spec.java.net
+jaxrs-spec@javaee.groups.io
 \end{quote}
 
 \section{Goals}
@@ -65,7 +65,7 @@ The following are non-goals:
 
 \begin{description}
 
-\item[Support for Java versions prior to J2SE 6.0] The API will make extensive use of annotations and will require J2SE 6.0 or later.
+\item[Support for Java versions prior to J2SE 8.0] The API will make extensive use of annotations and lambda expressions that require J2SE 8.0 or later.
 
 \item[Description, registration and discovery] The specification will neither define nor require any service description, registration or discovery capability.
 
@@ -124,7 +124,7 @@ This is a note.
 \section{Expert Group Members} 
 \label{expert_group}
 
-This specification is being developed as part of JSR 339 under the Java Community Process. It is the result of the collaborative work of the members of the JSR 339 Expert Group. The following are the present expert group members:
+This specification is being developed as part of JSR 370 under the Java Community Process. It is the result of the collaborative work of the members of the JSR 370 Expert Group. The following are the present expert group members:
 
 \begin{list}{$-$}{\parsep 0em \labelwidth 0em}
 \item Jan Algermissen (Individual Member)
@@ -136,7 +136,7 @@ This specification is being developed as part of JSR 339 under the Java Communit
 \item Bill De Hora (Individual Member)  
 \item Markus Karg (Individual Member) 
 \item Sastri Malladi (Ebay) 
-\item Wendy Raschke (IBM)
+\item Andy McCright (IBM)
 \item Julian Reschke (Individual Member)
 \item Guilherme Silveira (Individual Member) 
 \item Dionysios Synodinos (Individual Member)


### PR DESCRIPTION
This update changes references to JAX-RS 2.0 to 2.1 and JSR 339 to 370. It also updates the IBM EG members, and updates the URLs/email addresses to remove references to java.net and replace them with the appropriate github/groups.io/etc URLs.